### PR TITLE
Add job name to TipsetHeight metric

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -80,7 +80,7 @@ var DefaultViews = []*view.View{
 	{
 		Measure:     TipsetHeight,
 		Aggregation: view.LastValue(),
-		TagKeys:     []tag.Key{TaskType},
+		TagKeys:     []tag.Key{TaskType, Job},
 	},
 	{
 		Name:        ProcessingFailure.Name() + "_total",


### PR DESCRIPTION
Allow to create dashboard trakcking height per job.